### PR TITLE
Added IncludeHasTeam to Get-PnPUnifiedGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added Set-PnPKnowledgeHubSite, Get-PnPKnowledgeHubSite and Remove-PnPKnowledgeHubSite cmdlets
 - Added Register-PnPTenantAppCatalog to create and register a new Tenant App Catalog
+- Added `IncludeHasTeam` flag to `Get-PnPUnifiedGroup` to include a `HasTeam` flag for each returned Office 365 Group indicating if a Microsoft Team has been set up for it
 
 ### Changed
 - Connect-PnPOnline with clientid and certificate will now, if API permissions have been granted for the Graph work with the PnP Graph Cmdlets. [PR #2515](https://github.com/SharePoint/PnP-PowerShell/pull/2515)
@@ -18,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Contributors
 - Lane Blundell [fastlaneb]
+- Koen Zomers [koenzomers]
 
 ## [3.19.2003.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added Set-PnPKnowledgeHubSite, Get-PnPKnowledgeHubSite and Remove-PnPKnowledgeHubSite cmdlets
 - Added Register-PnPTenantAppCatalog to create and register a new Tenant App Catalog
-- Added `IncludeHasTeam` flag to `Get-PnPUnifiedGroup` to include a `HasTeam` flag for each returned Office 365 Group indicating if a Microsoft Team has been set up for it
+- Added `IncludeHasTeam` flag to `Get-PnPUnifiedGroup` to include a `HasTeam` flag for each returned Office 365 Group indicating if a Microsoft Team has been set up for it [PR #2612](https://github.com/SharePoint/PnP-PowerShell/pull/2612)
 
 ### Changed
 - Connect-PnPOnline with clientid and certificate will now, if API permissions have been granted for the Graph work with the PnP Graph Cmdlets. [PR #2515](https://github.com/SharePoint/PnP-PowerShell/pull/2515)

--- a/Commands/Graph/GetUnifiedGroup.cs
+++ b/Commands/Graph/GetUnifiedGroup.cs
@@ -32,6 +32,10 @@ namespace SharePointPnP.PowerShell.Commands.Graph
        Code = "PS:> Get-PnPUnifiedGroup -Identity $group",
        Remarks = "Retrieves a specific Office 365 Group based on its object instance",
        SortOrder = 5)]
+    [CmdletExample(
+       Code = "PS:> Get-PnPUnifiedGroup -IncludeIfHasTeam",
+       Remarks = "Retrieves all the Office 365 Groups and checks for each of them if it has a Microsoft Team provisioned for it",
+       SortOrder = 6)]
     public class GetUnifiedGroup : PnPGraphCmdlet
     {
         [Parameter(Mandatory = false, HelpMessage = "The Identity of the Office 365 Group.")]
@@ -42,6 +46,9 @@ namespace SharePointPnP.PowerShell.Commands.Graph
 
         [Parameter(Mandatory = false, HelpMessage = "Include Classification value of Office 365 Groups.")]
         public SwitchParameter IncludeClassification;
+
+        [Parameter(Mandatory = false, HelpMessage = "Include a flag for every Office 365 Group if it has a Microsoft Team provisioned for it. This will slow down the retrieval of Office 365 Groups so only use it if you need it.")]
+        public SwitchParameter IncludeHasTeam;
 
         protected override void ExecuteCmdlet()
         {
@@ -55,7 +62,7 @@ namespace SharePointPnP.PowerShell.Commands.Graph
             else
             {
                 // Retrieve all the groups
-                groups = UnifiedGroupsUtility.ListUnifiedGroups(AccessToken, includeSite: !ExcludeSiteUrl.IsPresent, includeClassification:IncludeClassification.IsPresent);
+                groups = UnifiedGroupsUtility.ListUnifiedGroups(AccessToken, includeSite: !ExcludeSiteUrl.IsPresent, includeClassification:IncludeClassification.IsPresent, includeHasTeam: IncludeHasTeam.IsPresent);
             }
 
             if (group != null)


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
Depends on https://github.com/pnp/PnP-Sites-Core/pull/2614 to be merged first.

## What is in this Pull Request ? ##
Added IncludeHasTeam to Get-PnPUnifiedGroup to allow checking for a Team provisioned for an Office 365 Group. Depends on https://github.com/pnp/PnP-Sites-Core/pull/2614 to be merged first.