### PR TITLE
Connect-PnPOnline -PnPO365ManagementShell is no longer language specific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Connect-PnPOnline with clientid and certificate will now, if API permissions have been granted for the Graph work with the PnP Graph Cmdlets. [PR #2515](https://github.com/SharePoint/PnP-PowerShell/pull/2515)
 - Save-PnPProvisioningTemplate and Save-PnPTenantTemplate now support XML file as input without the need to first read them into a variable with Read-PnPProvisioningTemplate or Read-PnPTenantTemplate
 - Added -Schema parameter to Save-PnPProvisioningTemplate and Save-PnPTenantTemplate to force a specific schema for the embedded template. If not specified it defaults always to the latest released template.
+- Fixed using `Connect-PnPOnline -PnPO365ManagementShell` only working if your default system language is English [PR #2613](https://github.com/SharePoint/PnP-PowerShell/pull/2613)
 
 ### Contributors
 - Lane Blundell [fastlaneb]
+- Koen Zomers [koenzomers]
 
 ## [3.19.2003.0]
 

--- a/Commands/Utilities/BrowserHelper.cs
+++ b/Commands/Utilities/BrowserHelper.cs
@@ -38,7 +38,7 @@ namespace SharePointPnP.PowerShell.Commands.Utilities
                 };
                 browser.Navigated += (sender, args) =>
                 {
-                    if(browser.DocumentText.Contains("You have signed in to the PnP Office 365 Management Shell application on your device. You may now close this window."))
+                    if(browser.Url.AbsoluteUri.Equals("https://login.microsoftonline.com/common/login", StringComparison.InvariantCultureIgnoreCase) || browser.Url.AbsoluteUri.StartsWith("https://login.microsoftonline.com/common/reprocess", StringComparison.InvariantCultureIgnoreCase))
                     {
                         form.Close();
                         success(true);


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Changed using `Connect-PnPOnline -PnPO365ManagementShell` only working if your default system language is English. This is done by no longer looking at the language specific text on the page indicating the logon has been successful, but looking at the URL it redirects to after a successful login instead.