### PR TITLE
Added Get-PnPSharingForNonOwnersOfSite and Disable-PnPSharingForNonOwnersOfSite 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [3.21.2005.0] (not yet released)
 
 ### Added
+- Added `Disable-PnPSharingForNonOwnersOfSite` and `Get-PnPSharingForNonOwnersOfSite` cmdlets to control disabling the ability for only owners of the site to be allowed to share the site or its files and folders with others
 
 ### Changed
 
 ### Contributors
+- Koen Zomers [koenzomers]
 
 ## [3.20.2004.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [3.21.2005.0] (not yet released)
 
 ### Added
-- Added `Disable-PnPSharingForNonOwnersOfSite` and `Get-PnPSharingForNonOwnersOfSite` cmdlets to control disabling the ability for only owners of the site to be allowed to share the site or its files and folders with others
+- Added `Disable-PnPSharingForNonOwnersOfSite` and `Get-PnPSharingForNonOwnersOfSite` cmdlets to control disabling the ability for only owners of the site to be allowed to share the site or its files and folders with others [PR #2641](https://github.com/pnp/PnP-PowerShell/pull/2641)
 
 ### Changed
 

--- a/Commands/SharePointPnP.PowerShell.Commands.csproj
+++ b/Commands/SharePointPnP.PowerShell.Commands.csproj
@@ -859,9 +859,11 @@
     <Compile Include="ClientSidePages\AddClientSideText.cs" />
     <Compile Include="Site\AddRoleDefinition.cs" />
     <Compile Include="Site\AddTeamsTeam.cs" />
+    <Compile Include="Site\GetSharingForNonOwnersOfSite.cs" />
     <Compile Include="Site\EnableCommSite.cs" />
     <Compile Include="Site\GetRoleDefinition.cs" />
     <Compile Include="Site\RemoveRoleDefinition.cs" />
+    <Compile Include="Site\DisableSharingForNonOwnersOfSite.cs" />
     <Compile Include="Site\TestOffice365GroupAliasIsUsed.cs" />
     <Compile Include="Taxonomy\NewTermLabel.cs" />
     <Compile Include="UserProfiles\GetUPABulkImportStatus.cs" />

--- a/Commands/Site/DisableSharingForNonOwnersOfSite.cs
+++ b/Commands/Site/DisableSharingForNonOwnersOfSite.cs
@@ -1,0 +1,47 @@
+﻿#if !ONPREMISES
+using Microsoft.Online.SharePoint.TenantManagement;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
+using System;
+using System.Management.Automation;
+
+namespace SharePointPnP.PowerShell.Commands.Site
+{
+    [Cmdlet(VerbsLifecycle.Disable, "PnPSharingForNonOwnersOfSite")]
+    [CmdletHelp("Configures the site to only allow sharing of the site and items in the site by owners",
+        DetailedDescription = "Configures the site to only allow sharing of the site and items in the site by owners. At this point there is no interface available yet to undo this action through script. You will have to do so through the user interface of SharePoint.",
+        Category = CmdletHelpCategory.Sites,
+        SupportedPlatform = CmdletSupportedPlatform.Online)]
+    [CmdletExample(
+        Code = @"PS:> Disable-PnPSharingForNonOwnersOfSite",
+        Remarks = "Restricts sharing of the site and items in the site only to owners",
+        SortOrder = 1)]
+
+    public class DisableSharingForNonOwnersOfSite : PnPCmdlet
+    {
+        [Parameter(Mandatory = false, ValueFromPipeline = true)]
+        [Alias("Url")]
+        public SitePipeBind Identity;
+
+        protected override void ExecuteCmdlet()
+        {
+            var context = ClientContext;
+            var site = ClientContext.Site;
+            var siteUrl = ClientContext.Url;
+
+            if(ParameterSpecified(nameof(Identity)))
+            {
+                context = ClientContext.Clone(Identity.Url);
+                site = context.Site;
+                siteUrl = context.Url;
+            }
+
+            Office365Tenant office365Tenant = new Office365Tenant(context);
+            context.Load(office365Tenant);
+            office365Tenant.DisableSharingForNonOwnersOfSite(siteUrl);
+            context.ExecuteQueryRetry();
+        }
+    }
+}
+#endif

--- a/Commands/Site/GetSharingForNonOwnersOfSite.cs
+++ b/Commands/Site/GetSharingForNonOwnersOfSite.cs
@@ -1,0 +1,50 @@
+﻿#if !ONPREMISES
+using Microsoft.Online.SharePoint.TenantManagement;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
+using System.Management.Automation;
+
+namespace SharePointPnP.PowerShell.Commands.Site
+{
+    [Cmdlet(VerbsCommon.Get, "PnPSharingForNonOwnersOfSite")]
+    [CmdletHelp("Returns $false if sharing of the site and items in the site is restricted only to owners or $true if members and owners are allowed to share",
+        DetailedDescription = "Returns $false if sharing of the site and items in the site is restricted only to owners or $true if members and owners are allowed to share. You can disable sharing by non owners by using Disable-PnPSharingForNonOwnersOfSite. At this point there is no interface available yet to enable sharing by owners and members again through script. You will have to do so through the user interface of SharePoint.",
+        Category = CmdletHelpCategory.Sites,
+        SupportedPlatform = CmdletSupportedPlatform.Online,
+        OutputType = typeof(bool))]
+    [CmdletExample(
+        Code = @"PS:> Get-PnPSharingForNonOwnersOfSite",
+        Remarks = "Returns $false if sharing of the site and items in the site is restricted only to owners or $true if members and owners are allowed to share",
+        SortOrder = 1)]
+
+    public class GetSharingForNonOwnersOfSite : PnPCmdlet
+    {
+        [Parameter(Mandatory = false, ValueFromPipeline = true)]
+        [Alias("Url")]
+        public SitePipeBind Identity;
+
+        protected override void ExecuteCmdlet()
+        {
+            var context = ClientContext;
+            var site = ClientContext.Site;
+            var siteUrl = ClientContext.Url;
+
+            if (ParameterSpecified(nameof(Identity)))
+            {
+                context = ClientContext.Clone(Identity.Url);
+                site = context.Site;
+                siteUrl = context.Url;
+            }
+
+            Office365Tenant office365Tenant = new Office365Tenant(context);
+            context.Load(office365Tenant);
+            var isSharingDisabledForNonOwnersOfSite = office365Tenant.IsSharingDisabledForNonOwnersOfSite(siteUrl);
+            context.ExecuteQueryRetry();
+
+            // Inverting the outcome here on purpose as the wording of the cmdlet indicates that a true means sharing for owners and members is allowed and false would mean only sharing for owners would be allowed
+            WriteObject(!isSharingDisabledForNonOwnersOfSite.Value);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
Issue #2640 

## What is in this Pull Request ? ##
Added `Get-PnPSharingForNonOwnersOfSite` and `Disable-PnPSharingForNonOwnersOfSite` to allow retrieval of the current state of being able to share the site and its items by only owners or also by its members. This is to accommodate issue #2640. It was not possible to add the current status to Get-PnPSite as requested due to the design of the SharePoint CSOM command. Therefore introduced two new commands. Unfortunately at this point there is no API yet to allow enabling the sharing again, thus there is no Enable-PnPSharingForNonOwnersOfSite.