### PR TITLE
Adding Get-PnPIsSiteAliasAvailable to check if alias is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Invoke-PnPSearchQuery: Allow SelectProperties to take a comma separated string as well as an array
+- Added `Get-PnPIsSiteAliasAvailable` which allows checking if a certain alias is still available to create a new site collection with [PR #2698](https://github.com/pnp/PnP-PowerShell/pull/2698)
 
 ### Contributors
+- Koen Zomers
 
 ## [3.20.2004.0]
 

--- a/Commands/SharePointPnP.PowerShell.Commands.csproj
+++ b/Commands/SharePointPnP.PowerShell.Commands.csproj
@@ -861,6 +861,7 @@
     <Compile Include="Site\AddTeamsTeam.cs" />
     <Compile Include="Site\EnableCommSite.cs" />
     <Compile Include="Site\GetRoleDefinition.cs" />
+    <Compile Include="Site\GetIsSiteAliasAvailable.cs" />
     <Compile Include="Site\RemoveRoleDefinition.cs" />
     <Compile Include="Site\TestOffice365GroupAliasIsUsed.cs" />
     <Compile Include="Taxonomy\NewTermLabel.cs" />

--- a/Commands/Site/GetIsSiteAliasAvailable.cs
+++ b/Commands/Site/GetIsSiteAliasAvailable.cs
@@ -1,0 +1,35 @@
+﻿#if !ONPREMISES
+using System.Management.Automation;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using System;
+
+namespace SharePointPnP.PowerShell.Commands
+{
+    [Cmdlet(VerbsCommon.Get, "PnPIsSiteAliasAvailable")]
+    [CmdletHelp("Validates if a certain alias is still available to be used to create a new site collection for. If it is not, it will propose an alternative alias and URL which is still available.",
+        OutputTypeDescription = "Returns a boolean IsAvailable indicating if the provided alias is still available to be used for a new site collection, a string ProposedUrl with the full proposed URL and a string ProposedAlias with just the alias to use instead if the provided alias is not available",
+        Category = CmdletHelpCategory.TenantAdmin, SupportedPlatform = CmdletSupportedPlatform.Online)]
+    [CmdletExample(
+        Code = @"PS:> Get-PnPIsSiteAliasAvailable -Identity ""HR""",
+        Remarks = @"Validates if the alias ""HR"" is still available to be used",
+        SortOrder = 1)]
+    public class GetIsSiteAliasAvailable : PnPCmdlet
+    {
+        [Parameter(Mandatory = false, HelpMessage = "Alias you want to check for if it is still available to create a new site collection for")]
+        [Alias("Alias")]
+        public string Identity;
+
+        protected override void ExecuteCmdlet()
+        {
+            var proposedUrl = OfficeDevPnP.Core.Sites.SiteCollection.GetValidSiteUrlFromAliasAsync(ClientContext, Identity).Result;
+
+            var record = new PSObject();
+            record.Properties.Add(new PSVariableProperty(new PSVariable("IsAvailable", proposedUrl.EndsWith($"/{Identity}", StringComparison.InvariantCultureIgnoreCase))));
+            record.Properties.Add(new PSVariableProperty(new PSVariable("ProposedAlias", proposedUrl.Remove(0, proposedUrl.LastIndexOf('/') + 1))));
+            record.Properties.Add(new PSVariableProperty(new PSVariable("ProposedUrl", proposedUrl)));
+
+            WriteObject(record);
+        }
+    }
+}
+#endif

--- a/Commands/Site/GetIsSiteAliasAvailable.cs
+++ b/Commands/Site/GetIsSiteAliasAvailable.cs
@@ -15,7 +15,7 @@ namespace SharePointPnP.PowerShell.Commands
         SortOrder = 1)]
     public class GetIsSiteAliasAvailable : PnPCmdlet
     {
-        [Parameter(Mandatory = false, HelpMessage = "Alias you want to check for if it is still available to create a new site collection for")]
+        [Parameter(Mandatory = false, HelpMessage = "Alias you want to check for if it is still available to create a new site collection for", ValueFromPipeline = true)]
         [Alias("Alias")]
         public string Identity;
 


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
Requested through https://github.com/pnp/PnP-PowerShell/issues/2695

## What is in this Pull Request ? ##
Adding `Get-PnPIsSiteAliasAvailable` to allow for checking if a certain alias is available to be used to create a new site collection with.

Depends on PnP Sites Core PR https://github.com/pnp/PnP-Sites-Core/pull/2657 to be merged first.

![image](https://user-images.githubusercontent.com/5940670/83138330-ef8ce080-a0ea-11ea-878e-9b01740687e0.png)
