### PR TITLE
Added check when connecting using a thumbprint that the private key certificate is available

### DIFF
--- a/Commands/Base/ConnectOnline.cs
+++ b/Commands/Base/ConnectOnline.cs
@@ -118,7 +118,7 @@ PS:> dir",
         SortOrder = 17)]
     [CmdletExample(
         Code = "PS:> Connect-PnPOnline -Url https://contoso.sharepoint.com -ClientId '<id>' -Tenant 'contoso.onmicrosoft.com' -Thumbprint 34CFAA860E5FB8C44335A38A097C1E41EEA206AA",
-        Remarks = "Connects to SharePoint using app-only tokens via an app's declared permission scopes. See https://github.com/SharePoint/PnP-PowerShell/tree/master/Samples/SharePoint.ConnectUsingAppPermissions for a sample on how to get started.",
+        Remarks = "Connects to SharePoint using app-only tokens via an app's declared permission scopes. See https://github.com/SharePoint/PnP-PowerShell/tree/master/Samples/SharePoint.ConnectUsingAppPermissions for a sample on how to get started. Ensure you have imported the private key certificate, typically the .pfx file, into the Windows Certificate Store for the certificate with the provided thumbprint.",
         SortOrder = 18)]
     [CmdletExample(
         Code = "PS:> Connect-PnPOnline -Url https://contoso.sharepoint.com -ClientId '<id>' -Tenant 'contoso.onmicrosoft.com' -PEMCertificate <PEM string> -PEMPrivateKey <PEM string> -CertificatePassword <if needed>",
@@ -502,7 +502,7 @@ PS:> Connect-PnPOnline -Url https://yourserver -ClientId <id> -HighTrustCertific
         [Parameter(Mandatory = true, ParameterSetName = ParameterSet_APPONLYAADPEM, HelpMessage = "PEM encoded private key for the certificate")]
         public string PEMPrivateKey;
 
-        [Parameter(Mandatory = true, ParameterSetName = ParameterSet_APPONLYAADThumb, HelpMessage = "Certificate thumbprint")]
+        [Parameter(Mandatory = true, ParameterSetName = ParameterSet_APPONLYAADThumb, HelpMessage = "The thumbprint of the certificate containing the private key registered with the application in Azure Active Directory")]
         public string Thumbprint;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_NATIVEAAD, HelpMessage = "Clears the token cache.")]
@@ -655,6 +655,8 @@ PS:> Connect-PnPOnline -Url https://yourserver -ClientId <id> -HighTrustCertific
             {
                 credentials = Credentials.Credential;
             }
+
+            WriteVerbose($"Using parameter set '{ParameterSetName}'");
 
             // Connect using the used set parameters
             switch (ParameterSetName)

--- a/Commands/Properties/Resources.Designer.cs
+++ b/Commands/Properties/Resources.Designer.cs
@@ -79,7 +79,16 @@ namespace SharePointPnP.PowerShell.Commands.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No certificate with the thumbprint &apos;{0}&apos; has been found in the Windows certificate store.
+        ///   Looks up a localized string similar to The provided certificate with the thumbprint &apos;{0}&apos; does not have a private key which is required for a connection to be established. Ensure you have imported the certificate containing the private key, typically the .pfx file, into the Windows Certificate Store..
+        /// </summary>
+        internal static string CertificateWithThumbprintDoesNotHavePrivateKey {
+            get {
+                return ResourceManager.GetString("CertificateWithThumbprintDoesNotHavePrivateKey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No certificate with the thumbprint &apos;{0}&apos; has been found in the Windows Certificate Store.
         /// </summary>
         internal static string CertificateWithThumbprintNotFound {
             get {

--- a/Commands/Properties/Resources.resx
+++ b/Commands/Properties/Resources.resx
@@ -328,7 +328,7 @@
     <value>No URL specified nor does the provided access token contain an audience</value>
   </data>
   <data name="CertificateWithThumbprintNotFound" xml:space="preserve">
-    <value>No certificate with the thumbprint '{0}' has been found in the Windows certificate store</value>
+    <value>No certificate with the thumbprint '{0}' has been found in the Windows Certificate Store</value>
   </data>
   <data name="ClientCertificateInvalid" xml:space="preserve">
     <value>The client certificate is invalid</value>
@@ -338,5 +338,8 @@
   </data>
   <data name="ParameterSetNotImplemented" xml:space="preserve">
     <value>Parameter set {0} has not yet been implemented. Please create an issue for this on GitHub.</value>
+  </data>
+  <data name="CertificateWithThumbprintDoesNotHavePrivateKey" xml:space="preserve">
+    <value>The provided certificate with the thumbprint '{0}' does not have a private key which is required for a connection to be established. Ensure you have imported the certificate containing the private key, typically the .pfx file, into the Windows Certificate Store.</value>
   </data>
 </root>


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample
- [X] Docfix

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Added verbose log to connect to show which parameter set a connect was matched with to aid in troubleshooting, added check when connecting using thumbprint, if the thumbprint resolves to the private key certificate and throw a clear warning if it resolves only to the public key certificate. Also updated documentation on the connect with thumbprint option that it requires the private key instead of the public key.