### PR TITLE
Add new cmdlet Get-PnPVersion to get platform and version of PnP PowerShell currently loaded

### DIFF
--- a/Commands/Base/GetVersion.cs
+++ b/Commands/Base/GetVersion.cs
@@ -1,0 +1,49 @@
+﻿using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using System.Management.Automation;
+using System.Reflection;
+
+namespace SharePointPnP.PowerShell.Commands.Base
+{
+    [Cmdlet(VerbsCommon.Get, "PnPVersion")]
+    [CmdletHelp("Returns the PnP PowerShell version currently loaded",
+        Category = CmdletHelpCategory.Base,
+        OutputType = typeof(GetVersionResult))]
+    [CmdletExample(
+        Code = "PS:> Get-PnPVersion",
+        Remarks = "Returns the PnP PowerShell version currently loaded",
+        SortOrder = 1)]
+    public class GetVersion : BasePSCmdlet
+    {
+        protected override void ExecuteCmdlet()
+        {
+            var result = new GetVersionResult();
+
+            var assembly = Assembly.GetExecutingAssembly();
+            result.Version = ((AssemblyFileVersionAttribute)assembly.GetCustomAttribute(typeof(AssemblyFileVersionAttribute))).Version;
+
+#if ONPREMISES
+#if SP2013
+            result.Platform = "SP2013";
+#elif SP2016
+            result.Platform = "SP2016";
+#elif SP2019
+            result.Platform = "SP2019";
+#else
+            // Unknown version (foolproof for next ONPREMISES versions)
+            result.Platform = "ONPREMISES";
+#endif
+#else
+            result.Platform = "SPO";
+#endif
+
+            WriteObject(result);
+        }
+    }
+
+    class GetVersionResult
+    {
+        public string Version { get; set; }
+
+        public string Platform { get; set; }
+    }
+}

--- a/Commands/SharePointPnP.PowerShell.Commands.csproj
+++ b/Commands/SharePointPnP.PowerShell.Commands.csproj
@@ -908,6 +908,7 @@
     <Compile Include="Utilities\CertificateHelper.cs" />
     <Compile Include="Utilities\Clipboard.cs" />
     <Compile Include="Utilities\FileUtilities.cs" />
+    <Compile Include="Base\GetVersion.cs" />
     <Compile Include="Utilities\IsolatedStorage.cs" />
     <Compile Include="Utilities\JwtUtility.cs" />
     <Compile Include="Utilities\OperatingSystem.cs" />


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #2719

## What is in this Pull Request ? ##
Add new cmdlet Get-PnPVersion to get platform and version of PnP PowerShell currently loaded .
The returned object has 2 properties Version and Platform.

SPO:
![image](https://user-images.githubusercontent.com/1153754/84513794-46d5a800-acca-11ea-8327-d4ce03e04437.png)

SP2013:
![image](https://user-images.githubusercontent.com/1153754/84513824-5228d380-acca-11ea-962b-28e775284007.png)

SP2016:
![image](https://user-images.githubusercontent.com/1153754/84513843-581eb480-acca-11ea-8202-a9f3c9fdf7f1.png)

SP2019:
![image](https://user-images.githubusercontent.com/1153754/84513858-5d7bff00-acca-11ea-953b-719251a1b614.png)

In case a new SP20XX version will be added, the Platform property will return a generic "ONPREMISES".