### PR TITLE
Fixed issue with Disconnect-PnPOnline not cleaning up certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
+- Fixed issue where using `Disconnect-PnPOnline -Connection $variable` after having connected using `$variable = Connect-PnPOnline -CertificatePath <path> -ReturnConnection`, it would not clean up the certificate on that connection instance passed in by $variable, but instead try to do it on the current connection context [PR #2755](https://github.com/pnp/PnP-PowerShell/pull/2755)
 
 ### Contributors
 - Gautam Sheth [gautamdsheth]
+- Koen Zomers [koenzomers]
 
 ## [3.22.2006.2]
 

--- a/Commands/Base/DisconnectOnline.cs
+++ b/Commands/Base/DisconnectOnline.cs
@@ -9,7 +9,8 @@ namespace SharePointPnP.PowerShell.Commands.Base
 {
     [Cmdlet(VerbsCommunications.Disconnect, "PnPOnline")]
     [CmdletHelp("Disconnects the context",
-        "Disconnects the current context and requires you to build up a new connection in order to use the Cmdlets again. Using Connect-PnPOnline to connect to a different site has the same effect.",
+        DetailedDescription = "Disconnects the current context and requires you to build up a new connection in order to use the Cmdlets again. Using Connect-PnPOnline to connect to a different site has the same effect.",
+        SupportedPlatform = CmdletSupportedPlatform.All,
         Category = CmdletHelpCategory.Base)]
     [CmdletExample(
         Code = @"PS:> Disconnect-PnPOnline",
@@ -22,16 +23,21 @@ namespace SharePointPnP.PowerShell.Commands.Base
 
         protected override void ProcessRecord()
         {
+            // If no specific connection has been passed in, take the connection from the current context
+            if(Connection == null)
+            {
+                Connection = PnPConnection.CurrentConnection;
+            }
 #if !ONPREMISES
-            if(PnPConnection.CurrentConnection?.Certificate != null)
+            if(Connection?.Certificate != null)
             {
 #if !NETSTANDARD2_1
-                PnPConnectionHelper.CleanupCryptoMachineKey(PnPConnection.CurrentConnection.Certificate);
+                PnPConnectionHelper.CleanupCryptoMachineKey(Connection.Certificate);
 #endif
-                PnPConnection.CurrentConnection.Certificate = null;
+                Connection.Certificate = null;
             }
 #endif
-                var success = false;
+            var success = false;
             if (Connection != null)
             {
                 success = DisconnectProvidedService(Connection);

--- a/Commands/Base/PnPConnectionHelper.cs
+++ b/Commands/Base/PnPConnectionHelper.cs
@@ -562,16 +562,28 @@ namespace SharePointPnP.PowerShell.Commands.Base
             return spoConnection;
         }
 
+        /// <summary>
+        /// Verifies if a local copy of the certificate has been stored in the machinekeys cache of Windows and if so, will remove it to avoid the cache from growing over time
+        /// </summary>
+        /// <param name="certificate">Certificate to validate if there is a local cached copy for and if so, delete it</param>
         internal static void CleanupCryptoMachineKey(X509Certificate2 certificate)
         {
             var privateKey = (RSACryptoServiceProvider)certificate.PrivateKey;
             string uniqueKeyContainerName = privateKey.CspKeyContainerInfo.UniqueKeyContainerName;
             certificate.Reset();
-            var path = Environment.GetEnvironmentVariable("ProgramData");
-            if (string.IsNullOrEmpty(path)) path = @"C:\ProgramData";
+            
+            var programDataPath = Environment.GetEnvironmentVariable("ProgramData");
+            if (string.IsNullOrEmpty(programDataPath))
+            {
+                programDataPath = @"C:\ProgramData";
+            }
             try
             {
-                System.IO.File.Delete(string.Format(@"{0}\Microsoft\Crypto\RSA\MachineKeys\{1}", path, uniqueKeyContainerName));
+                var temporaryCertificateFilePath = $@"{programDataPath}\Microsoft\Crypto\RSA\MachineKeys\{uniqueKeyContainerName}";
+                if (System.IO.File.Exists(temporaryCertificateFilePath))
+                {
+                    System.IO.File.Delete(temporaryCertificateFilePath);
+                }
             }
             catch (Exception)
             {


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Could play a role in some degree to https://github.com/pnp/PnP-PowerShell/issues/2752

## What is in this Pull Request ? ##
In `Disconnect-PnPOnline -Connection $variable`, if having connected using `$variable = Connect-PnPOnline -CertificatePath -ReturnConnection`, it would not clean up the certificate on that connection instance, but instead try to do it on the current connection context. That has been fixed in this PR.