### PR TITLE
Change to the removal of the certificate from the MachineKeys on Disconnect-PnPOnline 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Fixed issue where using `Disconnect-PnPOnline -Connection $variable` after having connected using `$variable = Connect-PnPOnline -CertificatePath <path> -ReturnConnection`, it would not clean up the certificate on that connection instance passed in by $variable, but instead try to do it on the current connection context [PR #2755](https://github.com/pnp/PnP-PowerShell/pull/2755)
+- Fixed issue where using `Connect-PnPOnline` using `-Thumbnail` would delete the private key on some devices when running `Disconnect-PnPOnline` [PR #2759](https://github.com/pnp/PnP-PowerShell/pull/2759)
 
 ### Contributors
 - Gautam Sheth [gautamdsheth]

--- a/Commands/Base/DisconnectOnline.cs
+++ b/Commands/Base/DisconnectOnline.cs
@@ -32,7 +32,10 @@ namespace SharePointPnP.PowerShell.Commands.Base
             if(Connection?.Certificate != null)
             {
 #if !NETSTANDARD2_1
-                PnPConnectionHelper.CleanupCryptoMachineKey(Connection.Certificate);
+                if (Connection != null && Connection.DeleteCertificateFromCacheOnDisconnect)
+                {
+                    PnPConnectionHelper.CleanupCryptoMachineKey(Connection.Certificate);
+                }
 #endif
                 Connection.Certificate = null;
             }

--- a/Commands/Base/PnPConnection.cs
+++ b/Commands/Base/PnPConnection.cs
@@ -80,6 +80,11 @@ namespace SharePointPnP.PowerShell.Commands.Base
         /// </summary>
         public X509Certificate2 Certificate { get; internal set; }
 
+        /// <summary>
+        /// Boolean indicating if when using Disconnect-PnPOnline to destruct this PnPConnection instance, if the certificate file should be deleted from C:\ProgramData\Microsoft\Crypto\RSA\MachineKeys
+        /// </summary>
+        public bool DeleteCertificateFromCacheOnDisconnect { get; internal set; }
+
         public ClientContext Context { get; set; }
 
         /// <summary>

--- a/Commands/Base/PnPConnectionHelper.cs
+++ b/Commands/Base/PnPConnectionHelper.cs
@@ -453,7 +453,7 @@ namespace SharePointPnP.PowerShell.Commands.Base
             string password = new System.Net.NetworkCredential(string.Empty, certificatePassword).Password;
             X509Certificate2 certificate = CertificateHelper.GetCertificateFromPEMstring(certificatePEM, privateKeyPEM, password);
 
-            return InitiateAzureAdAppOnlyConnectionWithCert(url, clientId, tenant, minimalHealthScore, retryCount, retryWait, requestTimeout, tenantAdminUrl, host, disableTelemetry, skipAdminCheck, azureEnvironment, certificate, true);
+            return InitiateAzureAdAppOnlyConnectionWithCert(url, clientId, tenant, minimalHealthScore, retryCount, retryWait, requestTimeout, tenantAdminUrl, host, disableTelemetry, skipAdminCheck, azureEnvironment, certificate, false);
         }
 
         /// <summary>
@@ -534,7 +534,8 @@ namespace SharePointPnP.PowerShell.Commands.Base
                 {
                     ConnectionMethod = ConnectionMethod.AzureADAppOnly,
                     Certificate = certificate,
-                    Tenant = tenant
+                    Tenant = tenant,
+                    DeleteCertificateFromCacheOnDisconnect = certificateFromFile
                 };
                 return spoConnection;
             }


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Discussed in https://github.com/pnp/PnP-PowerShell/issues/2752

## What is in this Pull Request ? ##
Change to only remove the certificate from the MachineKeys on Disconnect-PnPOnline if the -CertificatePath has been used to connect as it seems to be causing weird side effects to some where it invalidates the private key.

-- PR on hold awaiting confirmation of test discussed in the issue thread --