### PR TITLE
Added OutputTypeLinks specified in the CmdletHelp to Get-Help output

### DIFF
--- a/ModuleFilesGenerator/HelpFileGenerator.cs
+++ b/ModuleFilesGenerator/HelpFileGenerator.cs
@@ -264,8 +264,13 @@ namespace SharePointPnP.PowerShell.ModuleFilesGenerator
         private XElement GetRelatedLinksElement(Model.CmdletInfo cmdletInfo)
         {
             var relatedLinksElement = new XElement(maml + "relatedLinks");
-            cmdletInfo.RelatedLinks.Insert(0, new CmdletRelatedLinkAttribute() { Text = "SharePoint Developer Patterns and Practices", Url = "http://aka.ms/sppnp" });
-
+            cmdletInfo.RelatedLinks.Insert(0, new CmdletRelatedLinkAttribute { Text = "SharePoint Developer Patterns and Practices", Url = "http://aka.ms/sppnp" });
+            
+            if(!string.IsNullOrEmpty(cmdletInfo.OutputTypeLink))
+            {
+                cmdletInfo.RelatedLinks.Insert(1, new CmdletRelatedLinkAttribute { Text = "Output type documentation", Url = cmdletInfo.OutputTypeLink });
+            }
+            
             foreach (var link in cmdletInfo.RelatedLinks)
             {
                 var navigationLinksElement = new XElement(maml + "navigationLink");


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
OutputTypeLinks specified in the CmdletHelp attribute will now be added to the RelatedLinks sections of Get-Help