### PR TITLE
Renamed Add-PnPOffice365GroupToSite to Add-Microsoft365GroupToSite

### DIFF
--- a/Commands/Admin/AddMicrosoft365GroupToSite.cs
+++ b/Commands/Admin/AddMicrosoft365GroupToSite.cs
@@ -9,7 +9,7 @@ using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
 
 namespace SharePointPnP.PowerShell.Commands.Admin
 {
-    [Cmdlet(VerbsCommon.Add, "PnPOffice365GroupToSite")]
+    [Cmdlet(VerbsCommon.Add, "PnPMicrosoft365GroupToSite")]
     [CmdletHelp("Groupifies a classic team site by creating a Microsoft 365 group for it and connecting the site with the newly created group",
         DetailedDescription = "This command allows you to add a Microsoft 365 Unified group to an existing classic site collection, also known as groupifying.",
         SupportedPlatform = CmdletSupportedPlatform.Online,
@@ -17,7 +17,8 @@ namespace SharePointPnP.PowerShell.Commands.Admin
     [CmdletExample(
         Code = @"PS:> Add-PnPOffice365GroupToSite -Url ""https://contoso.sharepoint.com/sites/FinanceTeamsite"" -Alias ""FinanceTeamsite"" -DisplayName = ""My finance team site group""",
         Remarks = @"This will groupify the FinanceTeamsite", SortOrder = 1)]
-    public class AddOffice365GroupToSite: PnPAdminCmdlet
+    [Alias("Add-PnPOffice365GroupToSite")]
+    public class AddMicrosoft365GroupToSite: PnPAdminCmdlet
     {
         [Parameter(Mandatory = true, HelpMessage = @"Url of the site to be connected to an Microsoft 365 Group")]
         public string Url;

--- a/Commands/Admin/AddOffice365GroupToSite.cs
+++ b/Commands/Admin/AddOffice365GroupToSite.cs
@@ -11,12 +11,12 @@ namespace SharePointPnP.PowerShell.Commands.Admin
 {
     [Cmdlet(VerbsCommon.Add, "PnPOffice365GroupToSite")]
     [CmdletHelp("Groupifies a classic team site by creating a Microsoft 365 group for it and connecting the site with the newly created group",
-        DetailedDescription = "This command allows you to add a Microsoft 365 Unified group to an existing classic site collection.",
+        DetailedDescription = "This command allows you to add a Microsoft 365 Unified group to an existing classic site collection, also known as groupifying.",
         SupportedPlatform = CmdletSupportedPlatform.Online,
         Category = CmdletHelpCategory.TenantAdmin)]
     [CmdletExample(
         Code = @"PS:> Add-PnPOffice365GroupToSite -Url ""https://contoso.sharepoint.com/sites/FinanceTeamsite"" -Alias ""FinanceTeamsite"" -DisplayName = ""My finance team site group""",
-        Remarks = @"This will add a group called MyGroup to the current site collection", SortOrder = 1)]
+        Remarks = @"This will groupify the FinanceTeamsite", SortOrder = 1)]
     public class AddOffice365GroupToSite: PnPAdminCmdlet
     {
         [Parameter(Mandatory = true, HelpMessage = @"Url of the site to be connected to an Microsoft 365 Group")]
@@ -43,7 +43,7 @@ namespace SharePointPnP.PowerShell.Commands.Admin
         [Parameter(Mandatory = false, HelpMessage = "If specified the site will be associated to the hubsite as identified by this id")]
         public GuidPipeBind HubSiteId;
 
-        [Parameter(Mandatory = false, HelpMessage = "The array UPN values of the group's owners.")]
+        [Parameter(Mandatory = false, HelpMessage = "The array UPN values of the group's owners")]
         public string[] Owners;
         protected override void ExecuteCmdlet()
         {            

--- a/Commands/SharePointPnP.PowerShell.Commands.csproj
+++ b/Commands/SharePointPnP.PowerShell.Commands.csproj
@@ -554,7 +554,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Admin\AddHubSiteAssociation.cs" />
-    <Compile Include="Admin\AddOffice365GroupToSite.cs" />
+    <Compile Include="Admin\AddMicrosoft365GroupToSite.cs" />
     <Compile Include="Admin\AddOrgAssetsLibrary.cs" />
     <Compile Include="Admin\AddSiteCollectionAppCatalog.cs" />
     <Compile Include="Admin\AddTenantTheme.cs" />


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample
- [X] Name change

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Renamed to comply with Office 365 Group -> Microsoft 365 Group name change. Added alias to old cmdlet name for backwards compatibility.