### PR TITLE
Set-PnPRequestAccessEmails cleanup

### DIFF
--- a/Commands/Web/SetRequestAccessEmails.cs
+++ b/Commands/Web/SetRequestAccessEmails.cs
@@ -64,10 +64,7 @@ namespace PnP.PowerShell.Commands
                     else
                     {
                         // Enable requesting access and set it to the default owners group
-                        // Code can be replaced by SelectedWeb.EnableRequestAccess(); once https://github.com/SharePoint/PnP-Sites-Core/pull/2533 has been accepted for merge.
-                        SelectedWeb.SetUseAccessRequestDefaultAndUpdate(true);
-                        SelectedWeb.Update();
-                        SelectedWeb.Context.ExecuteQueryRetry();
+                        SelectedWeb.EnableRequestAccess();
                     }
                 }
             }


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/PnP-PowerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
No real issue, just some code cleanup

## What is in this Pull Request ? ##
While working on a different issue I stumbled upon the comment left in https://github.com/pnp/PnP-PowerShell/commit/9b8643ac2c34495d2f8ee029d65fc9472c9fa1b5 and as https://github.com/pnp/PnP-Sites-Core/pull/2533 has been merged, PnP PowerShell can use the function defined in PnP-Sites-Core instead of having a copy of the same code

I tested ```Set-PnPRequestAccessEmails -Disabled:$false``` in a Team Site on SPO and it changed the setting correctly.