### PR TITLE
Improve error messages when a valid certificate cannot be loaded from the given path

### DIFF
--- a/Commands/Utilities/CertificateHelper.cs
+++ b/Commands/Utilities/CertificateHelper.cs
@@ -142,16 +142,30 @@ namespace PnP.PowerShell.Commands.Utilities
 
         internal static X509Certificate2 GetCertificateFromPath(string certificatePath, SecureString certificatePassword)
         {
-            var certFile = System.IO.File.OpenRead(certificatePath);
-            var certificateBytes = new byte[certFile.Length];
-            certFile.Read(certificateBytes, 0, (int)certFile.Length);
-            var certificate = new X509Certificate2(
-                certificateBytes,
-                certificatePassword,
-                X509KeyStorageFlags.Exportable |
-                X509KeyStorageFlags.MachineKeySet |
-                X509KeyStorageFlags.PersistKeySet);
-            return certificate;
+            if (System.IO.File.Exists(certificatePath))
+            {
+                var certFile = System.IO.File.OpenRead(certificatePath);
+                if (certFile.Length == 0)
+                    throw new Exception($"The specified certificate path '{certificatePath}' points to an empty file");
+
+                var certificateBytes = new byte[certFile.Length];
+                certFile.Read(certificateBytes, 0, (int)certFile.Length);
+                var certificate = new X509Certificate2(
+                    certificateBytes,
+                    certificatePassword,
+                    X509KeyStorageFlags.Exportable |
+                    X509KeyStorageFlags.MachineKeySet |
+                    X509KeyStorageFlags.PersistKeySet);
+                return certificate;
+            }
+            else if (System.IO.Directory.Exists(certificatePath))
+            {
+                throw new FileNotFoundException($"The specified certificate path '{certificatePath}' points to a folder", certificatePath);
+            }
+            else
+            {
+                throw new FileNotFoundException($"The specified certificate path '{certificatePath}' does not exist", certificatePath);
+            }
         }
 
 


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/PnP-PowerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Improves the troubleshooting of #2879

## What is in this Pull Request ? ##
This PR improves the error messages displayed when a valid certificate cannot be loaded from the given path.

Handled cases:
1. The path is a folder (before it would say "Access to Path 'C:\Temp' is denied")
![image](https://user-images.githubusercontent.com/1153754/92130575-2f0f4b00-ee05-11ea-9ecb-a287e3f9d1e1.png)

1. The path doesn't exist at all
![image](https://user-images.githubusercontent.com/1153754/92130720-5bc36280-ee05-11ea-9463-c370d5bf1851.png)

1. The path is an empty file (before it would say "Array may not be empty or null")
![image](https://user-images.githubusercontent.com/1153754/92130778-6b42ab80-ee05-11ea-9879-3f7cb26d93fe.png)



### Guidance ###
* You can delete this section when you are submitting the pull request.* 
* *Please update this PR information accordingly. We use this as part of our release notes in monthly communications.*
* **Please target your PR to Dev branch. If you do not target the Dev branch we will not accept this PR.**
