### PR TITLE
ContentType/ListItem PipeBind parameter handling improvements

### DIFF
--- a/Commands/Base/PipeBinds/ContentTypePipeBind.cs
+++ b/Commands/Base/PipeBinds/ContentTypePipeBind.cs
@@ -1,75 +1,150 @@
-﻿using Microsoft.SharePoint.Client;
+﻿using System;
+using System.Management.Automation;
+
+using Microsoft.SharePoint.Client;
 
 namespace PnP.PowerShell.Commands.Base.PipeBinds
 {
     public sealed class ContentTypePipeBind
     {
-        private readonly string _id;
-        private readonly string _name;
+        private readonly string _idOrName;
         private readonly ContentType _contentType;
 
-        public ContentTypePipeBind()
+        public ContentTypePipeBind(string idOrName)
         {
-            _id = string.Empty;
-            _name = string.Empty;
-            _contentType = null;
+            if (string.IsNullOrEmpty(idOrName))
+                throw new ArgumentException("Content type name or ID null or empty.", nameof(idOrName));
+
+            _idOrName = idOrName;
         }
 
-        public ContentTypePipeBind(string id)
+        public ContentTypePipeBind(ContentTypeId contentTypeId)
         {
-            if (id.ToLower().StartsWith("0x0"))
-            {
-                _id = id;
-            }
-            else
-            {
-                _name = id;
-            }
-
+            _idOrName = contentTypeId?.StringValue
+                ?? throw new ArgumentNullException(nameof(contentTypeId));
         }
 
         public ContentTypePipeBind(ContentType contentType)
         {
-            _contentType = contentType;
+            _contentType = contentType
+                ?? throw new ArgumentNullException(nameof(contentType));
         }
 
-        public string Id
+        private string GetId()
+            => _contentType?.EnsureProperty(ct => ct.StringId)
+            ?? (_idOrName.ToLower().StartsWith("0x0") ? _idOrName : null);
+
+        public string GetId(Web web, bool searchInSiteHierarchy = true)
+            => GetId()
+            ?? web.GetContentTypeByName(_idOrName, searchInSiteHierarchy)?.StringId;
+
+        public string GetId(List list)
+            => GetId()
+            ?? list.GetContentTypeByName(_idOrName)?.StringId;
+
+        internal string GetIdOrThrow(string paramName, Web web, bool searchInSiteHierarchy = true)
+            => GetId(web, searchInSiteHierarchy)
+            ?? throw new PSArgumentException(NotFoundMessage(web, searchInSiteHierarchy), paramName);
+
+        internal string GetIdOrThrow(string paramName, List list)
+            => GetId(list)
+            ?? throw new PSArgumentException(NotFoundMessage(list), paramName);
+
+
+        public string GetIdOrWarn(Cmdlet cmdlet, Web web, bool searchInSiteHierarchy = true)
         {
-            get
-            {
-                if (_contentType != null)
-                {
-                    return _contentType.StringId;
-                }
-                else
-                {
-                    return _id;
-                }
-            }
+            var id = GetId(web, searchInSiteHierarchy);
+            if (id is null)
+                cmdlet.WriteWarning(NotFoundMessage(web, searchInSiteHierarchy));
+
+            return id;
         }
 
-        public string Name => _name;
-
-        public ContentType ContentType => _contentType;
-
-        public ContentType GetContentType(Web web)
+        public string GetIdOrWarn(Cmdlet cmdlet, List list)
         {
-            if (ContentType != null)
-            {
-                return ContentType;
-            }
-            ContentType ct;
-            if (!string.IsNullOrEmpty(Id))
-            {
-                ct = web.GetContentTypeById(Id,true);
+            var id = GetId(list);
+            if (id is null)
+                cmdlet.WriteWarning(NotFoundMessage(list));
 
-            }
-            else
-            {
-                ct = web.GetContentTypeByName(Name,true);
-            }
+            return id;
+        }
+
+        internal ContentType GetContentType(Web web, bool searchInSiteHierarchy = true)
+        {
+            if (_contentType is object)
+                return _contentType;
+
+            var id = GetId();
+            if (!string.IsNullOrEmpty(id))
+                return web.GetContentTypeById(id, searchInSiteHierarchy);
+
+            return web.GetContentTypeByName(_idOrName, searchInSiteHierarchy);
+        }
+
+        internal ContentType GetContentType(List list)
+        {
+            if (_contentType is object)
+                return _contentType;
+
+            var id = GetId();
+            if (!string.IsNullOrEmpty(id))
+                return list.ContentTypes.GetById(id);
+
+            return list.GetContentTypeByName(_idOrName);
+        }
+
+        internal ContentType GetContentTypeOrThrow(string paramName, Web web, bool searchInSiteHierarchy = true)
+            => GetContentType(web)
+            ?? throw new PSArgumentException(NotFoundMessage(web, searchInSiteHierarchy), paramName);
+
+        internal ContentType GetContentTypeOrError(Cmdlet cmdlet, string paramName, Web web, bool searchInSiteHierarchy = true)
+        {
+            var ct = GetContentType(web, searchInSiteHierarchy);
+            if (ct is null)
+                cmdlet.WriteError(new ErrorRecord(new PSArgumentException(NotFoundMessage(web, searchInSiteHierarchy), paramName), "CONTENTTYPEDOESNOTEXIST", ErrorCategory.InvalidArgument, this));
+            return ct;
+        }
+
+        internal ContentType GetContentTypeOrThrow(string paramName, List list)
+            => GetContentType(list)
+            ?? throw new PSArgumentException(NotFoundMessage(list), paramName);
+
+        internal ContentType GetContentTypeOrError(Cmdlet cmdlet, string paramName, List list)
+        {
+            var ct = GetContentType(list);
+            if (ct is null)
+                cmdlet.WriteError(new ErrorRecord(new PSArgumentException(NotFoundMessage(list), paramName), "CONTENTTYPEDOESNOTEXIST", ErrorCategory.InvalidArgument, this));
+            return ct;
+        }
+
+        internal ContentType GetContentTypeOrWarn(Cmdlet cmdlet, Web web, bool searchInSiteHierarchy = true)
+        {
+            var ct = GetContentType(web, searchInSiteHierarchy);
+            if (ct is null)
+                cmdlet.WriteWarning(NotFoundMessage(web, searchInSiteHierarchy));
 
             return ct;
         }
+
+        internal ContentType GetContentTypeOrWarn(Cmdlet cmdlet, List list)
+        {
+            var ct = GetContentType(list);
+            if (ct is null)
+                cmdlet.WriteWarning(NotFoundMessage(list));
+
+            return ct;
+        }
+
+        private string NotFoundMessage(Web web, bool searchInSiteHierarchy)
+            => $"Content type '{this}' not found in site {(searchInSiteHierarchy ? "hierachy" : "")}.";
+
+        private string NotFoundMessage(List list)
+            => $"Content type '{this}' not found in list '{new ListPipeBind(list)}'.";
+
+        public override string ToString()
+            => _idOrName
+            ?? (_contentType.IsPropertyAvailable(ct => ct.Name) ? _contentType.Name : null)
+            ?? (_contentType.IsObjectPropertyInstantiated(ct => ct.StringId) ? _contentType.StringId : null)
+            ?? $"[ContentType object with no name or Id]";
     }
 }

--- a/Commands/Base/PipeBinds/ListPipeBind.cs
+++ b/Commands/Base/PipeBinds/ListPipeBind.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.SharePoint.Client;
+
 using System;
+using System.Management.Automation;
 
 namespace PnP.PowerShell.Commands.Base.PipeBinds
 {
@@ -9,16 +11,9 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
         private readonly Guid _id;
         private readonly string _name;
 
-        public ListPipeBind()
-        {
-            _list = null;
-            _id = Guid.Empty;
-            _name = string.Empty;
-        }
-
         public ListPipeBind(List list)
         {
-            _list = list;
+            _list = list ?? throw new ArgumentNullException(nameof(list));
         }
 
         public ListPipeBind(Guid guid)
@@ -28,46 +23,36 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
 
         public ListPipeBind(string id)
         {
+            if (string.IsNullOrEmpty(id))
+                throw new ArgumentNullException(nameof(id));
+
             if (!Guid.TryParse(id, out _id))
-            {
                 _name = id;
-            }
         }
 
-        public Guid Id => _id;
-
-        public List List => _list;
-
-        public string Title => _name;
-
-        public override string ToString()
-        {
-            return Title ?? Id.ToString();
-        }
-
-        internal List GetList(Web web, params System.Linq.Expressions.Expression<Func<List,object>>[] retrievals)
+        internal List GetList(Web web, params System.Linq.Expressions.Expression<Func<List, object>>[] retrievals)
         {
             List list = null;
-            if (List != null)
+            if (_list != null)
             {
-                list = List;
+                list = _list;
             }
-            else if (Id != Guid.Empty)
+            else if (_id != Guid.Empty)
             {
-                list = web.Lists.GetById(Id);
+                list = web.Lists.GetById(_id);
             }
-            else if (!string.IsNullOrEmpty(Title))
+            else if (!string.IsNullOrEmpty(_name))
             {
-                list = web.GetListByTitle(Title);
+                list = web.GetListByTitle(_name);
                 if (list == null)
                 {
-                    list = web.GetListByUrl(Title);
+                    list = web.GetListByUrl(_name);
                 }
             }
             if (list != null)
             {
                 web.Context.Load(list, l => l.Id, l => l.BaseTemplate, l => l.OnQuickLaunch, l => l.DefaultViewUrl, l => l.Title, l => l.Hidden, l => l.ContentTypesEnabled, l => l.RootFolder.ServerRelativeUrl);
-                if(retrievals != null)
+                if (retrievals != null)
                 {
                     web.Context.Load(list, retrievals);
                 }
@@ -75,5 +60,28 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             }
             return list;
         }
+
+        internal List GetListOrThrow(string paramName, Web selectedWeb, params System.Linq.Expressions.Expression<Func<List, object>>[] retrievals)
+            => GetList(selectedWeb, retrievals)
+            ?? throw new PSArgumentException(NoListMessage, paramName);
+
+        internal List GetListOrWarn(Cmdlet cmdlet, Web web, params System.Linq.Expressions.Expression<Func<List, object>>[] retrievals)
+        {
+            var list = GetList(web, retrievals);
+            if (list is null)
+                cmdlet.WriteWarning(NoListMessage);
+
+            return list;
+        }
+
+        private string NoListMessage
+            => $"No list found with id, title or url '{this}'";
+
+        public override string ToString()
+            => _name
+            ?? (_id != Guid.Empty ? _id.ToString() : null)
+            ?? (_list.IsPropertyAvailable(l => l.Title) ? _list.Title : null)
+            ?? (_list.IsPropertyAvailable(l => l.Id) ? _list.Id.ToString() : null)
+            ?? "[List object with no Title or Id]";
     }
 }

--- a/Commands/ClientSidePages/SetClientSidePage.cs
+++ b/Commands/ClientSidePages/SetClientSidePage.cs
@@ -67,6 +67,7 @@ namespace PnP.PowerShell.Commands.ClientSidePages
         public ClientSidePageHeaderType HeaderType;
 
         [Parameter(Mandatory = false, HelpMessage = "Specify either the name, ID or an actual content type.")]
+        [ValidateNotNullOrEmpty]
         public ContentTypePipeBind ContentType;
 
         [Parameter(Mandatory = false, HelpMessage = "Thumbnail Url")]
@@ -90,7 +91,6 @@ namespace PnP.PowerShell.Commands.ClientSidePages
 
         protected override void ExecuteCmdlet()
         {
-
             ClientSidePage clientSidePage = Identity?.GetPage(ClientContext);
 
             if (clientSidePage == null)
@@ -109,7 +109,7 @@ namespace PnP.PowerShell.Commands.ClientSidePages
                 clientSidePage.PageTitle = Title;
             }
 
-            if(ThumbnailUrl != null)
+            if (ThumbnailUrl != null)
             {
                 clientSidePage.ThumbnailUrl = ThumbnailUrl;
             }
@@ -139,7 +139,8 @@ namespace PnP.PowerShell.Commands.ClientSidePages
             if (PromoteAs == ClientSidePagePromoteType.Template)
             {
                 clientSidePage.SaveAsTemplate(name);
-            } else
+            }
+            else
             {
                 clientSidePage.Save(name);
             }
@@ -170,29 +171,13 @@ namespace PnP.PowerShell.Commands.ClientSidePages
                 }
             }
 
-            if(ParameterSpecified(nameof(ContentType)))
+            if (ContentType != null)
             {
-                ContentType ct = null;
-                if (ContentType.ContentType == null)
-                {
-                    if (ContentType.Id != null)
-                    {
-                        ct = SelectedWeb.GetContentTypeById(ContentType.Id, true);
-                    }
-                    else if (ContentType.Name != null)
-                    {
-                        ct = SelectedWeb.GetContentTypeByName(ContentType.Name, true);
-                    }
-                }
-                else
-                {
-                    ct = ContentType.ContentType;
-                }
-                if (ct != null)
-                {
-                    ct.EnsureProperty(w => w.StringId);
+                string ctId = ContentType.GetIdOrWarn(this, SelectedWeb);
 
-                    clientSidePage.PageListItem["ContentTypeId"] = ct.StringId;
+                if (ctId != null)
+                {
+                    clientSidePage.PageListItem["ContentTypeId"] = ctId;
                     clientSidePage.PageListItem.SystemUpdate();
                     ClientContext.ExecuteQueryRetry();
                 }

--- a/Commands/ContentTypes/AddContentTypeToList.cs
+++ b/Commands/ContentTypes/AddContentTypeToList.cs
@@ -1,23 +1,27 @@
 ﻿using System.Management.Automation;
+
 using Microsoft.SharePoint.Client;
+
 using PnP.PowerShell.CmdletHelpAttributes;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 
 namespace PnP.PowerShell.Commands.ContentTypes
 {
     [Cmdlet(VerbsCommon.Add, "PnPContentTypeToList")]
-    [CmdletHelp("Adds a new content type to a list", 
+    [CmdletHelp("Adds a new content type to a list",
         Category = CmdletHelpCategory.ContentTypes)]
     [CmdletExample(
         Code = @"PS:> Add-PnPContentTypeToList -List ""Documents"" -ContentType ""Project Document"" -DefaultContentType",
-        Remarks = @"This will add an existing content type to a list and sets it as the default content type", 
+        Remarks = @"This will add an existing content type to a list and sets it as the default content type",
         SortOrder = 1)]
     public class AddContentTypeToList : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, HelpMessage = "Specifies the list to which the content type needs to be added")]
+        [ValidateNotNullOrEmpty]
         public ListPipeBind List;
 
         [Parameter(Mandatory = true, HelpMessage = "Specifies the content type that needs to be added to the list")]
+        [ValidateNotNullOrEmpty]
         public ContentTypePipeBind ContentType;
 
         [Parameter(Mandatory = false, HelpMessage = "Specify if the content type needs to be the default content type or not")]
@@ -25,31 +29,13 @@ namespace PnP.PowerShell.Commands.ContentTypes
 
         protected override void ExecuteCmdlet()
         {
-            ContentType ct = null;
-            List list = List.GetList(SelectedWeb);
-            if (list == null)
-                throw new PSArgumentException($"No list found with id, title or url '{List}'", "List");
+            var list = List.GetListOrThrow(nameof(List), SelectedWeb);
+            var ct = ContentType?.GetContentTypeOrWarn(this, list);
 
-            if (ContentType.ContentType == null)
-            {
-                if (ContentType.Id != null)
-                {
-                    ct = SelectedWeb.GetContentTypeById(ContentType.Id, true);
-                }
-                else if (ContentType.Name != null)
-                {
-                    ct = SelectedWeb.GetContentTypeByName(ContentType.Name, true);
-                }
-            }
-            else
-            {
-                ct = ContentType.ContentType;
-            }
             if (ct != null)
             {
                 SelectedWeb.AddContentTypeToList(list.Title, ct, DefaultContentType);
             }
         }
-
     }
 }

--- a/Commands/ContentTypes/AddFieldToContentType.cs
+++ b/Commands/ContentTypes/AddFieldToContentType.cs
@@ -1,17 +1,19 @@
 ﻿using System;
 using System.Management.Automation;
+
 using Microsoft.SharePoint.Client;
+
 using PnP.PowerShell.CmdletHelpAttributes;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 
 namespace PnP.PowerShell.Commands.ContentTypes
 {
     [Cmdlet(VerbsCommon.Add, "PnPFieldToContentType")]
-    [CmdletHelp("Adds an existing site column to a content type", 
+    [CmdletHelp("Adds an existing site column to a content type",
         Category = CmdletHelpCategory.ContentTypes)]
     [CmdletExample(
         Code = @"PS:> Add-PnPFieldToContentType -Field ""Project_Name"" -ContentType ""Project Document""",
-        Remarks = @"This will add an existing site column with an internal name of ""Project_Name"" to a content type called ""Project Document""", 
+        Remarks = @"This will add an existing site column with an internal name of ""Project_Name"" to a content type called ""Project Document""",
         SortOrder = 1)]
     public class AddFieldToContentType : PnPWebCmdlet
     {
@@ -19,6 +21,7 @@ namespace PnP.PowerShell.Commands.ContentTypes
         public FieldPipeBind Field;
 
         [Parameter(Mandatory = true, HelpMessage = "Specifies which content type a field needs to be added to")]
+        [ValidateNotNullOrEmpty]
         public ContentTypePipeBind ContentType;
 
         [Parameter(Mandatory = false, HelpMessage = "Specifies whether the field is required or not")]
@@ -43,36 +46,15 @@ namespace PnP.PowerShell.Commands.ContentTypes
                 ClientContext.Load(field);
                 ClientContext.ExecuteQueryRetry();
             }
-            if (field != null)
-            {
-                if (ContentType.ContentType != null)
-                {
-                    SelectedWeb.AddFieldToContentType(ContentType.ContentType, field, Required, Hidden);
-                }
-                else
-                {
-                    ContentType ct;
-                    if (!string.IsNullOrEmpty(ContentType.Id))
-                    {
-                        ct = SelectedWeb.GetContentTypeById(ContentType.Id);
-                      
-                    }
-                    else
-                    {
-                        ct = SelectedWeb.GetContentTypeByName(ContentType.Name);
-                    }
-                    if (ct != null)
-                    {
-                        SelectedWeb.AddFieldToContentType(ct, field, Required, Hidden);
-                    }
-                }
-            }
-            else
-            {
+
+            if (field is null)
                 throw new Exception("Field not found");
+
+            var ct = ContentType.GetContentTypeOrWarn(this, SelectedWeb);
+            if (ct != null)
+            {
+                SelectedWeb.AddFieldToContentType(ct, field, Required, Hidden);
             }
         }
-
-
     }
 }

--- a/Commands/ContentTypes/GetContentType.cs
+++ b/Commands/ContentTypes/GetContentType.cs
@@ -32,91 +32,57 @@ namespace PnP.PowerShell.Commands.ContentTypes
     public class GetContentType : PnPWebCmdlet
     {
         [Parameter(Mandatory = false, Position = 0, ValueFromPipeline = true, HelpMessage = "Name or ID of the content type to retrieve")]
+        [ValidateNotNullOrEmpty]
         public ContentTypePipeBind Identity;
+
         [Parameter(Mandatory = false, ValueFromPipeline = true, HelpMessage = "List to query")]
+        [ValidateNotNullOrEmpty]
         public ListPipeBind List;
+
         [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Search site hierarchy for content types")]
         public SwitchParameter InSiteHierarchy;
 
         protected override void ExecuteCmdlet()
         {
-
-            if (Identity != null)
+            if (List != null)
             {
-                if (List == null)
-                {
-                    ContentType ct;
-                    if (!string.IsNullOrEmpty(Identity.Id))
-                    {
-                        ct = SelectedWeb.GetContentTypeById(Identity.Id, InSiteHierarchy.IsPresent);
-                    }
-                    else
-                    {
-                        ct = SelectedWeb.GetContentTypeByName(Identity.Name, InSiteHierarchy.IsPresent);
-                    }
-                    if (ct != null)
-                    {
+                var list = List?.GetListOrThrow(nameof(List), SelectedWeb);
 
-                        WriteObject(ct);
-                    }
+                if (Identity != null)
+                {
+                    var ct = Identity.GetContentTypeOrError(this, nameof(Identity), list);
+
+                    if (ct is null)
+                        return;
+
+                    WriteObject(ct, false);
                 }
                 else
                 {
-                    List list = List.GetList(SelectedWeb);
-                    if (list == null)
-                        throw new PSArgumentException($"No list found with id, title or url '{List}'", "List");
-
+                    var cts = ClientContext.LoadQuery(list.ContentTypes.Include(ct => ct.Id, ct => ct.Name, ct => ct.StringId, ct => ct.Group));
                     ClientContext.ExecuteQueryRetry();
-
-                    if (!string.IsNullOrEmpty(Identity.Id))
-                    {
-                        if(list.ContentTypeExistsById(Identity.Id))
-                        {
-                            var cts = list.GetContentTypeById(Identity.Id);
-                            ClientContext.Load(cts);
-                            ClientContext.ExecuteQueryRetry();
-                            WriteObject(cts, false);
-                        }
-                        else
-                        {
-                            WriteError(new ErrorRecord(new ArgumentException(String.Format("Content Type Id: {0} does not exist in the list: {1}", Identity.Id, list.Title)), "CONTENTTYPEDOESNOTEXIST", ErrorCategory.InvalidArgument, this));
-                            
-                        }
-                    }
-                    else if (!string.IsNullOrEmpty(Identity.Name))
-                    {
-                        if (list.ContentTypeExistsByName(Identity.Name))
-                        {
-                            var cts = list.GetContentTypeByName(Identity.Name);
-                            ClientContext.Load(cts);
-                            ClientContext.ExecuteQueryRetry();
-                            WriteObject(cts, false);
-                        }
-                        else
-                        {
-                            WriteError(new ErrorRecord(new ArgumentException(String.Format("Content Type Name: {0} does not exist in the list: {1}", Identity.Name, list.Title)), "CONTENTTYPEDOESNOTEXIST", ErrorCategory.InvalidArgument, this));
-                        
-                        }
-                     
-                    }
+                    WriteObject(cts, true);
                 }
             }
             else
             {
-                if (List == null)
+                if (Identity != null)
                 {
-                    var cts = (InSiteHierarchy.IsPresent) ? ClientContext.LoadQuery(SelectedWeb.AvailableContentTypes) : ClientContext.LoadQuery(SelectedWeb.ContentTypes);
-                    ClientContext.ExecuteQueryRetry();
+                    var ct = Identity.GetContentTypeOrError(this, nameof(Identity), SelectedWeb, InSiteHierarchy);
 
-                    WriteObject(cts, true);
+                    if (ct is null)
+                        return;
+
+                    WriteObject(ct, false);
                 }
                 else
                 {
-                    List list = List.GetList(SelectedWeb);
-                    if (list == null)
-                        throw new PSArgumentException($"No list found with id, title or url '{List}'", "List");
-                    var cts = ClientContext.LoadQuery(list.ContentTypes.Include(ct => ct.Id, ct => ct.Name, ct => ct.StringId, ct => ct.Group));
+                    var cts = InSiteHierarchy
+                    ? ClientContext.LoadQuery(SelectedWeb.AvailableContentTypes)
+                    : ClientContext.LoadQuery(SelectedWeb.ContentTypes);
+
                     ClientContext.ExecuteQueryRetry();
+
                     WriteObject(cts, true);
                 }
             }

--- a/Commands/ContentTypes/RemoveContentType.cs
+++ b/Commands/ContentTypes/RemoveContentType.cs
@@ -1,13 +1,16 @@
 ﻿using System.Management.Automation;
+
 using Microsoft.SharePoint.Client;
+
 using PnP.PowerShell.CmdletHelpAttributes;
 using PnP.PowerShell.Commands.Base.PipeBinds;
+
 using Resources = PnP.PowerShell.Commands.Properties.Resources;
 
 namespace PnP.PowerShell.Commands.ContentTypes
 {
     [Cmdlet(VerbsCommon.Remove, "PnPContentType")]
-    [CmdletHelp("Removes a content type from a web", 
+    [CmdletHelp("Removes a content type from a web",
         Category = CmdletHelpCategory.ContentTypes)]
     [CmdletExample(
         Code = @"PS:> Remove-PnPContentType -Identity ""Project Document""",
@@ -19,8 +22,7 @@ namespace PnP.PowerShell.Commands.ContentTypes
         SortOrder = 2)]
     public class RemoveContentType : PnPWebCmdlet
     {
-
-        [Parameter(Mandatory = true, Position=0, ValueFromPipeline=true, HelpMessage="The name or ID of the content type to remove")]
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, HelpMessage = "The name or ID of the content type to remove")]
         public ContentTypePipeBind Identity;
 
         [Parameter(Mandatory = false, HelpMessage = "Specifying the Force parameter will skip the confirmation question.")]
@@ -28,30 +30,12 @@ namespace PnP.PowerShell.Commands.ContentTypes
 
         protected override void ExecuteCmdlet()
         {
-            if (Force || ShouldContinue(Resources.RemoveContentType, Resources.Confirm))
-            {
-                ContentType ct = null;
-                if (Identity.ContentType != null)
-                {
-                    ct = Identity.ContentType;
-                }
-                else
-                {
-                    if (!string.IsNullOrEmpty(Identity.Id))
-                    {
-                        ct = SelectedWeb.GetContentTypeById(Identity.Id);
-                    }
-                    else if (!string.IsNullOrEmpty(Identity.Name))
-                    {
-                        ct = SelectedWeb.GetContentTypeByName(Identity.Name);
-                    }
-                }
-                if(ct != null)
-                {
-                    ct.DeleteObject();
-                    ClientContext.ExecuteQueryRetry();
-                }
+            var ct = Identity?.GetContentTypeOrWarn(this, SelectedWeb);
 
+            if (ct != null || Force || ShouldContinue(Resources.RemoveContentType, Resources.Confirm))
+            {
+                ct.DeleteObject();
+                ClientContext.ExecuteQueryRetry();
             }
         }
     }

--- a/Commands/ContentTypes/RemoveContentTypeFromList.cs
+++ b/Commands/ContentTypes/RemoveContentTypeFromList.cs
@@ -1,5 +1,7 @@
 ﻿using System.Management.Automation;
+
 using Microsoft.SharePoint.Client;
+
 using PnP.PowerShell.CmdletHelpAttributes;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 
@@ -7,7 +9,7 @@ namespace PnP.PowerShell.Commands.ContentTypes
 {
 
     [Cmdlet(VerbsCommon.Remove, "PnPContentTypeFromList")]
-    [CmdletHelp("Removes a content type from a list", 
+    [CmdletHelp("Removes a content type from a list",
         Category = CmdletHelpCategory.ContentTypes)]
     [CmdletExample(
         Code = @"PS:> Remove-PnPContentTypeFromList -List ""Documents"" -ContentType ""Project Document""",
@@ -16,36 +18,21 @@ namespace PnP.PowerShell.Commands.ContentTypes
     public class RemoveContentTypeFromList : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, HelpMessage = "The name of the list, its ID or an actual list object from where the content type needs to be removed from")]
+        [ValidateNotNullOrEmpty]
         public ListPipeBind List;
 
         [Parameter(Mandatory = true, HelpMessage = "The name of a content type, its ID or an actual content type object that needs to be removed from the specified list.")]
+        [ValidateNotNullOrEmpty]
         public ContentTypePipeBind ContentType;
 
         protected override void ExecuteCmdlet()
         {
-            ContentType ct = null;
-            List list = List.GetList(SelectedWeb);
-
-            if (ContentType.ContentType == null)
-            {
-                if (ContentType.Id != null)
-                {
-                    ct = SelectedWeb.GetContentTypeById(ContentType.Id,true);
-                }
-                else if (ContentType.Name != null)
-                {
-                    ct = SelectedWeb.GetContentTypeByName(ContentType.Name,true);
-                }
-            }
-            else
-            {
-                ct = ContentType.ContentType;
-            }
+            var list = List.GetListOrThrow(nameof(List), SelectedWeb);
+            var ct = ContentType.GetContentTypeOrWarn(this, list);
             if (ct != null)
             {
                 SelectedWeb.RemoveContentTypeFromList(list, ct);
             }
         }
-
     }
 }

--- a/Commands/ContentTypes/SetDefaultContentTypeToList.cs
+++ b/Commands/ContentTypes/SetDefaultContentTypeToList.cs
@@ -1,54 +1,36 @@
-﻿using System.Management.Automation;
+﻿using System;
+using System.Management.Automation;
+
 using Microsoft.SharePoint.Client;
+
 using PnP.PowerShell.CmdletHelpAttributes;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 
 namespace PnP.PowerShell.Commands.ContentTypes
 {
-
     [Cmdlet(VerbsCommon.Set, "PnPDefaultContentTypeToList")]
-    [CmdletHelp("Sets the default content type for a list", 
+    [CmdletHelp("Sets the default content type for a list",
         Category = CmdletHelpCategory.ContentTypes)]
     [CmdletExample(
         Code = @"PS:> Set-PnPDefaultContentTypeToList -List ""Project Documents"" -ContentType ""Project""",
-        Remarks = @"This will set the Project content type (which has already been added to a list) as the default content type", 
+        Remarks = @"This will set the Project content type (which has already been added to a list) as the default content type",
         SortOrder = 1)]
     public class SetDefaultContentTypeToList : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, HelpMessage = "The name of a list, an ID or the actual list object to update")]
+        [ValidateNotNullOrEmpty]
         public ListPipeBind List;
 
         [Parameter(Mandatory = true, HelpMessage = "The content type object that needs to be set as the default content type on the list. Content Type needs to be present on the list.")]
+        [ValidateNotNullOrEmpty]
         public ContentTypePipeBind ContentType;
 
         protected override void ExecuteCmdlet()
         {
-            ContentType ct = null;
-            List list = List.GetList(SelectedWeb);
+            var list = List.GetListOrThrow(nameof(List), SelectedWeb);
+            var ctId = ContentType.GetIdOrThrow(nameof(ContentType), list);
 
-            if (ContentType.ContentType == null)
-            {
-                if (ContentType.Id != null)
-                {
-                    ct = list.GetContentTypeById(ContentType.Id);
-                }
-                else if (ContentType.Name != null)
-                {
-                    ct = list.GetContentTypeByName(ContentType.Name);
-                }
-            }
-            else
-            {
-                ct = ContentType.ContentType;
-                if(!list.ContentTypeExistsById(ct.Id.ToString()))
-                {
-                    WriteError(new ErrorRecord(new System.Exception("Content type does not exist on list. Use Add-PnPContentTypeToList to add the content type first."), "CONTENTTYPENOTADDEDTOLIST", ErrorCategory.ResourceUnavailable, ct));
-                }
-            }
-            if (ct != null)
-            {
-                list.SetDefaultContentType(ct.Id);
-            }
+            list.SetDefaultContentType(ctId);
         }
 
     }

--- a/Commands/Lists/AddListItem.cs
+++ b/Commands/Lists/AddListItem.cs
@@ -3,7 +3,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
+
 using Microsoft.SharePoint.Client;
+
 using PnP.PowerShell.CmdletHelpAttributes;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 using PnP.PowerShell.Commands.Enums;
@@ -42,9 +44,11 @@ namespace PnP.PowerShell.Commands.Lists
     public class AddListItem : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, HelpMessage = "The ID, Title or Url of the list.")]
+        [ValidateNotNullOrEmpty]
         public ListPipeBind List;
 
         [Parameter(Mandatory = false, HelpMessage = "Specify either the name, ID or an actual content type.")]
+        [ValidateNotNullOrEmpty]
         public ContentTypePipeBind ContentType;
 
         [Parameter(Mandatory = false, HelpMessage = "Use the internal names of the fields when specifying field names." +
@@ -100,27 +104,10 @@ namespace PnP.PowerShell.Commands.Lists
 
                 if (ContentType != null)
                 {
-                    ContentType ct = null;
-                    if (ContentType.ContentType == null)
+                    var ctId = ContentType.GetIdOrWarn(this, list);
+                    if (ctId != null)
                     {
-                        if (ContentType.Id != null)
-                        {
-                            ct = SelectedWeb.GetContentTypeById(ContentType.Id, true);
-                        }
-                        else if (ContentType.Name != null)
-                        {
-                            ct = SelectedWeb.GetContentTypeByName(ContentType.Name, true);
-                        }
-                    }
-                    else
-                    {
-                        ct = ContentType.ContentType;
-                    }
-                    if (ct != null)
-                    {
-                        ct.EnsureProperty(w => w.StringId);
-
-                        item["ContentTypeId"] = ct.StringId;
+                        item["ContentTypeId"] = ctId;
                         item.Update();
                         ClientContext.ExecuteQueryRetry();
                     }

--- a/Commands/Principals/SetGroupPermissions.cs
+++ b/Commands/Principals/SetGroupPermissions.cs
@@ -37,7 +37,8 @@ namespace PnP.PowerShell.Commands.Principals
         public GroupPipeBind Identity = new GroupPipeBind();
 
         [Parameter(Mandatory = false, HelpMessage = "The list to apply the command to.")]
-        public ListPipeBind List = new ListPipeBind();
+        [ValidateNotNullOrEmpty]
+        public ListPipeBind List;
 
         [Parameter(Mandatory = false, HelpMessage = "Name of the permission set to add to this SharePoint group")]
         public string[] AddRole = null;
@@ -48,16 +49,8 @@ namespace PnP.PowerShell.Commands.Principals
         protected override void ExecuteCmdlet()
         {
             var group = Identity.GetGroup(SelectedWeb);
-            
-            List list = List.GetList(SelectedWeb);
-            if (list == null && !string.IsNullOrEmpty(List.Title))
-            {
-                throw new Exception($"List with Title {List.Title} not found");
-            }
-            else if (list == null && List.Id != Guid.Empty )
-            {
-                throw new Exception($"List with Id {List.Id} not found");
-            }
+
+            List list = List.GetListOrThrow(nameof(List), SelectedWeb);
 
             if (AddRole != null)
             {

--- a/Commands/Provisioning/Site/AddDataRowsToProvisioningTemplate.cs
+++ b/Commands/Provisioning/Site/AddDataRowsToProvisioningTemplate.cs
@@ -1,11 +1,14 @@
 ﻿using Microsoft.SharePoint.Client;
+
 using OfficeDevPnP.Core.Framework.Provisioning.Connectors;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using OfficeDevPnP.Core.Framework.Provisioning.Providers;
 using OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml;
+
 using PnP.PowerShell.CmdletHelpAttributes;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 using PnP.PowerShell.Commands.Utilities;
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -13,6 +16,7 @@ using System.Linq;
 using System.Management.Automation;
 using System.Text;
 using System.Text.RegularExpressions;
+
 using SPSite = Microsoft.SharePoint.Client.Site;
 
 namespace PnP.PowerShell.Commands.Provisioning.Site
@@ -31,12 +35,15 @@ namespace PnP.PowerShell.Commands.Provisioning.Site
     public class AddDataRowsToProvisioningTemplate : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, Position = 0, HelpMessage = "Filename of the .PNP Open XML site template to read from, optionally including full path.")]
+        [ValidateNotNullOrEmpty]
         public string Path;
 
         [Parameter(Mandatory = true, HelpMessage = "The list to query")]
+        [ValidateNotNullOrEmpty]
         public ListPipeBind List;
 
         [Parameter(Mandatory = false, HelpMessage = "The CAML query to execute against the list. Defaults to all items.")]
+        [ValidateNotNullOrEmpty]
         public string Query;
 
         [Parameter(Mandatory = false, HelpMessage = "The fields to retrieve. If not specified all fields will be loaded in the returned list object.")]
@@ -77,21 +84,20 @@ namespace PnP.PowerShell.Commands.Provisioning.Site
             }
             //We will remove a list if it's found so we can get the list
 
-            ListInstance listInstance = template.Lists.Find(l => l.Title == List.Title);
+            List spList = List.GetListOrThrow(nameof(List), SelectedWeb,
+                l => l.RootFolder, l => l.HasUniqueRoleAssignments);
+
+            ListInstance listInstance = template.Lists.Find(l => l.Title == spList.Title);
             if (listInstance == null)
             {
                 throw new ApplicationException("List does not exist in the template file!");
             }
 
-            List spList = List.GetList(SelectedWeb);
-            ClientContext.Load(spList, l => l.RootFolder, l => l.HasUniqueRoleAssignments);
-            ClientContext.ExecuteQueryRetry();
-
             if (TokenizeUrls.IsPresent)
             {
                 ClientContext.Load(ClientContext.Web, w => w.Url, w => w.ServerRelativeUrl, w => w.Id);
                 ClientContext.Load(ClientContext.Site, s => s.Url, s => s.ServerRelativeUrl, s => s.Id);
-                ClientContext.Load(ClientContext.Web.Lists, lists => lists.Include(l=>l.Title, l => l.RootFolder.ServerRelativeUrl));
+                ClientContext.Load(ClientContext.Web.Lists, lists => lists.Include(l => l.Title, l => l.RootFolder.ServerRelativeUrl));
             }
 
             CamlQuery query = new CamlQuery();
@@ -231,7 +237,7 @@ namespace PnP.PowerShell.Commands.Provisioning.Site
                     return $"{urlValue.Url},{urlValue.Description}";
                 case FieldType.Lookup:
                     var strVal = rawValue as string;
-                    if(strVal != null)
+                    if (strVal != null)
                     {
                         return strVal;
                     }
@@ -255,7 +261,7 @@ namespace PnP.PowerShell.Commands.Provisioning.Site
                     var multipleUserValue = rawValue as FieldUserValue[];
                     if (multipleUserValue != null)
                     {
-                        return string.Join(",", multipleUserValue.Select(lv => GetLoginName(web,lv.LookupId)));
+                        return string.Join(",", multipleUserValue.Select(lv => GetLoginName(web, lv.LookupId)));
                     }
                     throw new Exception("Invalid data in field");
                 case FieldType.MultiChoice:

--- a/Commands/Webhooks/RemoveWebhookSubscription.cs
+++ b/Commands/Webhooks/RemoveWebhookSubscription.cs
@@ -1,9 +1,12 @@
 ﻿#if !ONPREMISES
 
 using Microsoft.SharePoint.Client;
+
 using OfficeDevPnP.Core.Entities;
+
 using PnP.PowerShell.CmdletHelpAttributes;
 using PnP.PowerShell.Commands.Base.PipeBinds;
+
 using System;
 using System.Management.Automation;
 
@@ -34,6 +37,7 @@ PS:> $subscriptions[0] | Remove-PnPWebhookSubscription -List MyList",
         public WebhookSubscriptionPipeBind Identity;
 
         [Parameter(Mandatory = false, HelpMessage = "The list object or name which the Webhook subscription will be removed from")]
+        [ValidateNotNullOrEmpty]
         public ListPipeBind List;
 
         [Parameter(Mandatory = false, HelpMessage = "Specifying the Force parameter will skip the confirmation question.")]
@@ -47,7 +51,7 @@ PS:> $subscriptions[0] | Remove-PnPWebhookSubscription -List MyList",
                 if (ParameterSpecified(nameof(List)))
                 {
                     // Get the list from the currently selected web
-                    List list = List.GetList(SelectedWeb);
+                    List list = List.GetListOrThrow(nameof(List), SelectedWeb);
                     if (list != null)
                     {
                         // Ensure we have list Id (and Title for the confirm message)
@@ -56,12 +60,11 @@ PS:> $subscriptions[0] | Remove-PnPWebhookSubscription -List MyList",
                         // Check the Force switch of ask confirm
                         if (Force
                             || ShouldContinue(string.Format(Properties.Resources.RemoveWebhookSubscription0From1_2,
-                                Identity.Id, Properties.Resources.List, List.Title), Properties.Resources.Confirm))
+                                Identity.Id, Properties.Resources.List, list.Title), Properties.Resources.Confirm))
                         {
                             // Remove the Webhook subscription for the specified Id
                             list.RemoveWebhookSubscription(Identity.Subscription);
                         }
-
                     }
                 }
                 else


### PR DESCRIPTION
Be more consistent with warnings/errors/terminating errors.
Cleans up a lot of duplicated code and make the pipebinds easier to use.

might fix #1963