### PR TITLE
Add new switch parameter "-AddToAllContentTypes" to Add-PnPField to automatically add the new field to all list content types

### DIFF
--- a/Commands/Fields/AddField.cs
+++ b/Commands/Fields/AddField.cs
@@ -70,6 +70,10 @@ namespace PnP.PowerShell.Commands.Fields
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_ADDFIELDBYXMLTOLIST, HelpMessage = "The group name to where this field belongs to")]
         public string Group;
 
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_ADDFIELDTOLIST, HelpMessage = "Switch Parameter if this field must be added to all content types")]
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_ADDFIELDBYXMLTOLIST, HelpMessage = "Switch Parameter if this field must be added to all content types")]
+        public SwitchParameter AddToAllContentTypes;
+
 #if !ONPREMISES
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_ADDFIELDTOLIST, HelpMessage = "The Client Side Component Id to set to the field")]
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_ADDFIELDTOWEB, HelpMessage = "The Client Side Component Id to set to the field")]
@@ -122,6 +126,10 @@ namespace PnP.PowerShell.Commands.Fields
                         Group = Group,
                         AddToDefaultView = AddToDefaultView
                     };
+
+                    if (AddToAllContentTypes)
+                        fieldCI.FieldOptions |= AddFieldOptions.AddToAllContentTypes;
+
 #if !ONPREMISES
                     if (ClientSideComponentId != null)
                     {


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Partially fixes https://github.com/pnp/PnP-PowerShell/issues/2535 . https://github.com/pnp/PnP-Sites-Core/pull/2754 in PnP-Sites-Core is required to be merged first.

## What is in this Pull Request ? ##
Add new switch parameter "-AddToAllContentTypes" to Add-PnPField to automatically add the new field to all list content types.
ParameterSet_ADDFIELDTOLIST and ParameterSet_ADDFIELDBYXMLTOLIST are supported.

Example:
```powershell
Connect-PnPOnline $siteUrl

#create list with 3 content types
$list = New-PnPList -Title "AddToAllContentTypes" -Template GenericList
Set-PnPList -Identity $list -EnableContentType $true
Add-PnPContentType -Name "CT1"
Add-PnPContentType -Name "CT2"
Add-PnPContentType -Name "CT3"
Add-PnPContentTypeToList -List $list -ContentType "CT1"
Add-PnPContentTypeToList -List $list -ContentType "CT2"
Add-PnPContentTypeToList -List $list -ContentType "CT3"

#add the field to all 3 content types
Add-PnPField -List $list -DisplayName "FieldForAllCTs" -InternalName "FieldForAllCTsInternal" -AddToDefaultView -Type Text -AddToAllContentTypes
```

![image](https://user-images.githubusercontent.com/1153754/92997248-2a881800-f512-11ea-88d5-506ac906e41a.png)
