### PR TITLE
Remove trailing '/' at the end of the url when calling Add-PnPStoredCredential

### DIFF
--- a/Commands/Utilities/CredentialManager.cs
+++ b/Commands/Utilities/CredentialManager.cs
@@ -21,6 +21,9 @@ namespace PnP.PowerShell.Commands.Utilities
             {
                 name = $"PnPPS:{name}";
             }
+
+            name = name.TrimEnd('/');
+
 #if !PNPPSCORE
             WriteWindowsCredentialManagerEntry(name, username, password);
             return true;


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #2920

## What is in this Pull Request ? ##
Remove trailing '/' at the end of the url when calling Add-PnPStoredCredential. I can't think of a case when it would be needed to keep the '/' character at the end of the url when stored in the credentials manager.
