### PR TITLE
Remove documentation on GrooveBlockOption

### DIFF
--- a/Commands/Admin/SetTenantSyncClientRestriction.cs
+++ b/Commands/Admin/SetTenantSyncClientRestriction.cs
@@ -41,7 +41,7 @@ You must have the SharePoint Online admin or Global admin role to run the cmdlet
         [Parameter(Mandatory = false, HelpMessage = @"Blocks certain file types from syncing with the new sync client (OneDrive.exe). Provide as one string separating the extensions using a semicolon (;). I.e. ""docx;pptx""")]
         public List<string> ExcludedFileExtensions;
 
-        [Parameter(Mandatory = false, HelpMessage = "Controls whether or not a tenant's users can sync OneDrive for Business libraries with the old OneDrive for Business sync client. The valid values are OptOut, HardOptin, and SoftOptin.")]
+        // Missing documentation is intended because the parameter is planned to be deprecated.
         public Enums.GrooveBlockOption GrooveBlockOption;
 
         protected override void ExecuteCmdlet()


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
GrooveBlockOption is planned to be deprecated. To prevent new tenants from using the parameter, remove it from the documentation.

## What is in this Pull Request ? ##
Removing Parameter attribute which is used to generate documentation for GrooveBlockOption parameter