### PR TITLE
Improve exception message when a provisioning template cannot be loaded from a file

### DIFF
--- a/Commands/Provisioning/Site/ReadProvisioningTemplate.cs
+++ b/Commands/Provisioning/Site/ReadProvisioningTemplate.cs
@@ -113,6 +113,9 @@ namespace PnP.PowerShell.Commands.Provisioning
 
             // Load the provisioning template file
             Stream stream = fileConnector.GetFileStream(templateFileName);
+            if (stream == null)
+                throw new FileNotFoundException($"File {templatePath} does not exist.", templatePath);
+
             var isOpenOfficeFile = FileUtilities.IsOpenOfficeFile(stream);
 
             XMLTemplateProvider provider;


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
None

## What is in this Pull Request ? ##
Currently a NullDereference exception is thrown if ```Add-PnPListFoldersToProvisioningTemplate``` is called with a path that doesn't exist:
![image](https://user-images.githubusercontent.com/1153754/94298008-b2840e00-ff65-11ea-88f8-46c9a561e090.png)

This PR handles the cases by throwing a FileNotFoundException with the path of the file:
![image](https://user-images.githubusercontent.com/1153754/94297986-ab5d0000-ff65-11ea-93bd-36fee8955eca.png)

Steps to reproduce the issue:
```powershell
Connect-PnPOnline "https://<tenant>.sharepoint.com/sites/<site>"
Add-PnPListFoldersToProvisioningTemplate -Path "SiteTemplate.pnp" -List "List name" -Recursive
```